### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/on_develop.yml
+++ b/.github/workflows/on_develop.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.3.0
         with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.3.0
         with:
             python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
           make tox
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5.1.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -44,10 +44,10 @@ jobs:
       - build
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: '3.7'
 
@@ -69,11 +69,11 @@ jobs:
       - publish
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/schedule-update-actions.yml
+++ b/.github/workflows/schedule-update-actions.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.PAT }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.PAT }}

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-2latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.1.2](https://github.com/codecov/codecov-action/releases/tag/v5.1.2)** on 2024-12-18T18:45:28Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.3.0](https://github.com/actions/setup-python/releases/tag/v5.3.0)** on 2024-10-24T14:15:17Z
* **[amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)** published a new release **[v5.5.3](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.5.3)** on 2024-06-28T07:05:47Z
* **[actions/create-release](https://github.com/actions/create-release)** published a new release **[v1.1.4](https://github.com/actions/create-release/releases/tag/v1.1.4)** on 2020-09-14T13:55:07Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
